### PR TITLE
Potential fix for code scanning alert no. 162: Database query built from user-controlled sources

### DIFF
--- a/back-end/src/controllers/auth/authController.ts
+++ b/back-end/src/controllers/auth/authController.ts
@@ -109,10 +109,13 @@ export const changeEmail: RequestHandler = async (req, res) => {
 	const { email: newEmail } = req.body;
 
 	if (!newEmail) return res.status(400).json({ message: "New email is required." });
+	if (typeof newEmail !== "string") {
+		return res.status(400).json({ message: "Invalid email." });
+	}
 
 	const session = req.session as CustomSession;
 	const conflictChecks = await Promise.all(
-		models.map(Model => Model.exists({ email: newEmail, _id: { $ne: ID } }))
+		models.map(Model => Model.exists({ email: { $eq: newEmail }, _id: { $ne: ID } }))
 	);
 	if (conflictChecks.some(Boolean)) {
 		return res.status(403).json({ message: "Email already exists." });


### PR DESCRIPTION
Potential fix for [https://github.com/anderson-webops/operationopportunity.jacobdanderson.net/security/code-scanning/162](https://github.com/anderson-webops/operationopportunity.jacobdanderson.net/security/code-scanning/162)

In general, to fix NoSQL injection issues in MongoDB/Mongoose queries, ensure that any user-controlled values used inside query objects are either (1) validated to be acceptable literal types (string, number, ObjectId, etc.) and rejected otherwise, or (2) wrapped in operators like `$eq` so that MongoDB interprets them only as literal values, not as objects containing other operators. This avoids cases where an attacker sends a query object with `$`-prefixed keys that Mongoose/MongoDB interpret specially.

For this specific issue, the safest and least intrusive fix is to validate `newEmail` as a string (and optionally, as a valid email format) before using it in the query, and to construct the query so `email` is compared as a literal value. CodeQL’s recommendation is to use `$eq`; however, many NoSQL-injection rules also accept explicit type checks as sufficient. A robust approach is:

1. Ensure `newEmail` is a string and optionally meets your email format requirements; otherwise, return a `400` response.
2. Use a query that treats `newEmail` as a scalar literal. You can either:
   - keep `email: newEmail` after type-checking (Mongoose will treat it as a literal string), or
   - explicitly use `$eq`: `email: { $eq: newEmail }`.

To minimize behavior changes and follow the generic guidance, we will (a) add a `typeof` check that `newEmail` is a string, and (b) wrap the email in `$eq` in the `exists` query. This all occurs inside `changeEmail` in `back-end/src/controllers/auth/authController.ts`, at lines 109–116 in the snippet. No additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
